### PR TITLE
Update config.rst

### DIFF
--- a/docs/source/mate/config.rst
+++ b/docs/source/mate/config.rst
@@ -25,7 +25,7 @@ Paste this into the file:
       "fragment": 1,
       "unique": 60,
       "databases": [ ],
-      "io": "confif/mate_serial.json"
+      "io": "config/mate_serial.json"
     }
 
 Save the file. Now we need to create another file:


### PR DESCRIPTION
Minor spelling error in the base.json code block. Caused an error when running the system later.